### PR TITLE
feat: copy device string without popover

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -46,10 +46,6 @@ window.app = Vue.createApp({
           rowsPerPage: 10
         }
       },
-      settingsDialog: {
-        show: false,
-        data: {}
-      },
       formDialog: {
         show: false,
         data: {}
@@ -142,13 +138,12 @@ window.app = Vue.createApp({
       this.formDialog.data = _.clone(lnpos)
       this.formDialog.show = true
     },
-    openSettings(lnposId) {
+    copyDeviceString(lnposId) {
       const lnpos = _.findWhere(this.lnposs, {
         id: lnposId
       })
-      this.deviceString = `${this.protocol}//${this.location}/lnpos/api/v1/lnurl/${lnpos.id},${lnpos.key},${lnpos.currency}`
-      this.settingsDialog.data = _.clone(lnpos)
-      this.settingsDialog.show = true
+      const deviceString = `${this.protocol}//${this.location}/lnpos/api/v1/lnurl/${lnpos.id},${lnpos.key},${lnpos.currency}`
+      this.copyText(deviceString)
     },
     updateLnpos(wallet, data) {
       const updatedData = {}

--- a/templates/lnpos/index.html
+++ b/templates/lnpos/index.html
@@ -88,11 +88,11 @@
                   flat
                   dense
                   size="xs"
-                  @click="openSettings(props.row.id)"
+                  @click="copyDeviceString(props.row.id)"
                   icon="perm_data_setting"
                   color="primary"
                 >
-                  <q-tooltip>LNPoS Settings</q-tooltip>
+                  <q-tooltip>LNPoS Device string</q-tooltip>
                 </q-btn>
               </q-td>
               <q-td
@@ -127,27 +127,6 @@
       </q-card-section>
     </q-card>
   </div>
-
-  <q-dialog
-    v-model="settingsDialog.show"
-    deviceition="top"
-    @hide="closeFormDialog"
-  >
-    <q-card class="q-pa-lg q-pt-xl lnbits__dialog-card">
-      <div class="text-h6">Device string</div>
-      <q-btn
-        dense
-        outline
-        unelevated
-        color="primary"
-        size="md"
-        @click="copyText(deviceString, 'Link copied to clipboard!')"
-      >
-        <span v-text="deviceString"></span>
-        <q-tooltip>Click to copy URL</q-tooltip>
-      </q-btn>
-    </q-card>
-  </q-dialog>
 
   <q-dialog v-model="formDialog.show" deviceition="top" @hide="closeFormDialog">
     <q-card class="q-pa-lg q-pt-xl lnbits__dialog-card">


### PR DESCRIPTION
its over the shoulder attack because the device secret is in the url, and the url was shown inside the copy.

changed to just copy the string instead of showing it in the popover