### PR TITLE
fix: payment_hash should be optional

### DIFF
--- a/models.py
+++ b/models.py
@@ -28,7 +28,7 @@ class Lnpos(BaseModel):
 class LnposPayment(BaseModel):
     id: str
     lnpos_id: str
-    payment_hash: str
     payload: str
     pin: int
     sats: int
+    payment_hash: Optional[str] = None

--- a/views.py
+++ b/views.py
@@ -36,6 +36,10 @@ async def displaypin(request: Request, payment_id: str):
     device = await get_lnpos(lnpos_payment.lnpos_id)
     if not device:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="lnpos not found.")
+    if not lnpos_payment.payment_hash:
+        raise HTTPException(
+            HTTPStatus.NOT_FOUND, "Payment_hash of lnpos_payment is missing."
+        )
     payment = await get_standalone_payment(lnpos_payment.payment_hash)
     if not payment:
         raise HTTPException(

--- a/views_lnurl.py
+++ b/views_lnurl.py
@@ -60,7 +60,6 @@ async def lnurl_v1_params(
         payload=p,
         sats=price_msat * 1000,
         pin=int(pin),
-        payment_hash="payment_hash",
     )
     await create_lnpos_payment(lnpos_payment)
     return {


### PR DESCRIPTION
not a random string. this is a bug, because it can happen you create multiple payments with this string and the resulting payments `SELECT * from lnpos_payments WHERE payment_hash="payment_hash";`could be the wrong payments