### PR TITLE
Fix: Add missing payload field to LnposPayment model

### DIFF
--- a/models.py
+++ b/models.py
@@ -27,6 +27,7 @@ class Lnpos(BaseModel):
 class LnposPayment(BaseModel):
     id: str
     lnpos_id: str
+    payload: str
     pin: int
     sats: int
     amount: float | None = None

--- a/views_lnurl.py
+++ b/views_lnurl.py
@@ -68,6 +68,7 @@ async def lnurl_params(
         lnpos_payment = LnposPayment(
             id=payload,
             lnpos_id=lnpos.id,
+            payload=payload,
             sats=price_sat,
             pin=int(pin),
             amount=amount if lnpos.currency != "sat" else None,


### PR DESCRIPTION
### Issue
Users scanning QR codes from hardware devices receive a "Invalid payload" error message, even though the encrypted payload is correctly formatted and can be decrypted successfully.

### Root Cause
The database schema requires a NOT NULL `payload` column in the `lnpos_payment` table (added in a previous migration), but the `LnposPayment` model and payment creation code were never updated to include this field. This causes an `IntegrityError` during payment creation:

```
sqlite3.IntegrityError: NOT NULL constraint failed: lnpos_payment.payload
```

The server catches this database error and returns a generic "Invalid payload" error to the user, making it appear as if the encryption/decryption failed when the actual issue is in the database layer.

### Solution
- Added `payload: str` field to the `LnposPayment` model in models.py
- Updated payment creation in views_lnurl.py to pass the `payload` parameter when creating `LnposPayment` instances

### Testing
Tested with encrypted payloads from ESP32 hardware devices using AES-256-CBC encryption. QR codes now scan successfully and payments are created without errors.

### Impact
This fix resolves the user-facing "Invalid payload" error and allows hardware devices to work correctly with the API v2 endpoint.